### PR TITLE
Fix docs for Group::addChild to match implementation

### DIFF
--- a/include/osg/Group
+++ b/include/osg/Group
@@ -43,7 +43,7 @@ class OSG_EXPORT Group : public Node
         virtual void traverse(NodeVisitor& nv);
 
         /** Add Node to Group.
-          * If node is not NULL and is not contained in Group then increment its
+          * If node is not NULL then increment its
           * reference count, add it to the child list and dirty the bounding
           * sphere to force it to recompute on next getBound() and return true for success.
           * Otherwise return false. Scene nodes can't be added as child nodes.


### PR DESCRIPTION
[Checking for duplicates](https://github.com/openscenegraph/OpenSceneGraph/blob/master/src/osg/Group.cpp#L77) is only done if ENSURE_CHILD_IS_UNIQUE is defined, but this is never defined anywhere.